### PR TITLE
Fix Update twilwind action

### DIFF
--- a/.github/workflows/update-tailwind.yml
+++ b/.github/workflows/update-tailwind.yml
@@ -14,7 +14,7 @@ jobs:
 
     - name: Update tailwind.css
       run: |
-        yarn upgrade tailwindcss
+        yarn upgrade --no-lockfile tailwindcss
         yarn build
 
     - name: Commit changes


### PR DESCRIPTION
The recent executions of the update tailwind GithUb action fail. This pull request will solve the issue, which comes down to a yarn error.